### PR TITLE
add standard ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard_template.md
+++ b/.github/ISSUE_TEMPLATE/standard_template.md
@@ -1,0 +1,31 @@
+---
+name: Standard Template
+about: Use this template for general tickets and tasks.
+title: "[TASK] <Brief description of the task>"
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+Please describe the task or problem in detail.
+
+...
+
+**Proposed Working Plan**
+Suggest one or more steps on how to address this task or solve the problem.
+
+...
+
+**This ticket is complete if**
+List the criteria that must be met for this ticket to be considered complete.
+
+...
+
+**Additional Comments**
+Add any other relevant comments, links, screenshots, or context information here.
+
+...
+
+**Due date**
+Once someone is assigned to work on this issue, an estimated completion date should be entered here to monitor progress.


### PR DESCRIPTION
Just added a first ticket template in order to have all kind of tickets and bugs in the same format of description, issue, name etc. This merge is just for planning and orga and didnt change any code